### PR TITLE
Pylint alerts corrections as part of intervention experiment: removing wildcard-import in examples\issues\issue37.py  

### DIFF
--- a/examples/issues/issue37.py
+++ b/examples/issues/issue37.py
@@ -1,5 +1,5 @@
-from cursesmenu import *
-from cursesmenu.items import *
+from cursesmenu import CursesMenu
+from cursesmenu.items import SubmenuItem
 
 menu = CursesMenu("Title", "Subtitle")
 selection_menu = CursesMenu.make_selection_menu([f"item{i}" for i in range(20)])

--- a/examples/issues/issue37.py
+++ b/examples/issues/issue37.py
@@ -1,5 +1,5 @@
-from cursesmenu import CursesMenu
-from cursesmenu.items.submenu_item import SubmenuItem
+from cursesmenu import *
+from cursesmenu.items import *
 
 menu = CursesMenu("Title", "Subtitle")
 selection_menu = CursesMenu.make_selection_menu([f"item{i}" for i in range(20)])

--- a/examples/issues/issue37.py
+++ b/examples/issues/issue37.py
@@ -1,5 +1,5 @@
-from cursesmenu import *
-from cursesmenu.items import *
+from cursesmenu import CursesMenu
+from cursesmenu.items.submenu_item import SubmenuItem
 
 menu = CursesMenu("Title", "Subtitle")
 selection_menu = CursesMenu.make_selection_menu([f"item{i}" for i in range(20)])


### PR DESCRIPTION
In general, wildcard imports should be avoided since the imported object are hidden. Actually, a working code might break due to adding object to the imported file, that will conflict with others.

Therefore I replaced the wildcard imports with the specific objects to import.